### PR TITLE
S3 fix for new workspace

### DIFF
--- a/src/Balsam/src/Balsam.Api/HubClient.cs
+++ b/src/Balsam/src/Balsam.Api/HubClient.cs
@@ -314,6 +314,9 @@ namespace Balsam.Api
         }
         private async Task CreateWorkspaceManifests(BalsamProject project, BalsamBranch branch, BalsamWorkspace workspace, UserInfo user, string workspacePath, string templateId)
         {
+            var token = await _s3Client.CreateAccessKeyAsync(project.S3.BucketName);
+            var s3Token = new S3Token(token.AccessKey, token.SecretKey);
+            user.S3 = s3Token;
             var context = new WorkspaceContext(project, branch, workspace, user);
             await CreateManifests(context, workspacePath, "workspaces" + Path.DirectorySeparatorChar +  templateId);
         }

--- a/src/Balsam/src/Balsam.Api/Models/S3Token.cs
+++ b/src/Balsam/src/Balsam.Api/Models/S3Token.cs
@@ -1,0 +1,14 @@
+﻿namespace Balsam.Api.Models
+{
+    public class S3Token
+    {
+        public string AccessKey { get; set; }
+        public string SecretKey{ get; set; }
+
+        public S3Token(string accessKey, string secretKey)
+        {
+            AccessKey = accessKey;
+            SecretKey = secretKey;
+        }
+    }
+}

--- a/src/Balsam/src/Balsam.Api/Models/UserInfo.cs
+++ b/src/Balsam/src/Balsam.Api/Models/UserInfo.cs
@@ -6,6 +6,8 @@
         public string Mail { get; set; }
         public string GitPAT { get; set; }
 
+        public S3Token S3 { get; set; }
+
         public UserInfo(string userName, string mail, string gitPAT)
         {
             UserName = userName;


### PR DESCRIPTION
This PR includes updates in:

**Balsam API**
- Retrieves a new s# token when creating a new workspace
- Adds new variables for S3 token that can be used from the workspace templates