### PR TITLE
Fix group name authurization in Baslam API

### DIFF
--- a/src/Balsam/src/Balsam.Api/Controllers/WorkspaceController.cs
+++ b/src/Balsam/src/Balsam.Api/Controllers/WorkspaceController.cs
@@ -30,9 +30,8 @@ namespace Balsam.Api.Controllers
             var username = this.User.Claims.FirstOrDefault(c => c.Type == "preferred_username")?.Value;
             var mail = this.User.Claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")?.Value;
             var project = await _hubClient.GetProject(createWorkspaceRequest.ProjectId);
-            var groups = this.User.Claims.FirstOrDefault(c => c.Type == "groups" && c.Value == project.Oidc.GroupId);
 
-            if (groups != null)
+            if (this.User.Claims.Any(c => c.Type == "groups" && c.Value == project.Oidc.GroupName))
             {
                 try
                 {
@@ -128,7 +127,7 @@ namespace Balsam.Api.Controllers
                 {
                     var project = await _hubClient.GetProject(projectId);
 
-                    if (this.User.Claims.FirstOrDefault(c => c.Type == "groups" && c.Value == project.Oidc.GroupId) is null)
+                    if (!this.User.Claims.Any(c => c.Type == "groups" && c.Value == project.Oidc.GroupName) )
                     {
                         return BadRequest(new Problem() { Status = 400, Type = "Not authorized", Title = "You are not a member of the project" });
                     }

--- a/src/Balsam/src/Balsam.Api/HubClient.cs
+++ b/src/Balsam/src/Balsam.Api/HubClient.cs
@@ -277,10 +277,12 @@ namespace Balsam.Api
             {
                 var patResponse = await _gitUserClient.CreatePATAsync(userName);
                 gitPAT = patResponse.Token;
+                _logger.LogInformation($"Git PAT created");
             }
             var user = new UserInfo(userName, userMail, gitPAT);
 
             string propPath = Path.Combine(workspacePath, "properties.json");
+            _logger.LogDebug("Pulling changes");
             _hubRepositoryClient.PullChanges();
             // serialize JSON to a string and then write string to a file
             await CreateWorkspaceManifests(project, branch, workspace, user, workspacePath, templateId);
@@ -288,7 +290,7 @@ namespace Balsam.Api
             workspace.Url = ManifestUtil.GetWorkspaceUrl(Path.Combine(workspacePath, template.UrlConfig));
             await System.IO.File.WriteAllTextAsync(propPath, JsonConvert.SerializeObject(workspace));
             _hubRepositoryClient.PersistChanges($"New workspace with id {project.Id}");
-
+            _logger.LogInformation("Workspace created");
             return workspace;
         }
 


### PR DESCRIPTION
This PR contains fixes in:

**Balsam API**
- Used GoupName instead of GroupId in authourization check
- Added some logging