### PR TITLE
Fixe for ListWorkpaces 

### DIFF
--- a/src/Balsam/src/Balsam.Api/HubClient.cs
+++ b/src/Balsam/src/Balsam.Api/HubClient.cs
@@ -568,7 +568,7 @@ namespace Balsam.Api
                 {
                     foreach (var branchPath in Directory.GetDirectories(projectPath))
                     {
-                        var userPath = Path.Combine(hubPath, userId);
+                        var userPath = Path.Combine(branchPath, userId);
 
                         if (System.IO.Directory.Exists(userPath))
                         {


### PR DESCRIPTION
This PR contains changes in:

**Balsam API**
-Fix for ListWorkspaces. Wrong directory was used when filtering on userId 