### PR TITLE
Change to git branch name

### DIFF
--- a/src/Balsam/src/Balsam.Api/HubClient.cs
+++ b/src/Balsam/src/Balsam.Api/HubClient.cs
@@ -366,14 +366,15 @@ namespace Balsam.Api
         {
 
             var project = await GetProject(projectId, false);
+            var branch = await GetBranch(projectId, fromBranch);
      
-            if (project is null || project.Git is null)
+            if (project is null || project.Git is null || branch is null || branch.GitBranch is null)
             {
                 return null;
             }
             
 
-            var response = await _repositoryApi.CreateBranchAsync(project.Git.Id, new GitProviderApiClient.Model.CreateBranchRequest(branchName, fromBranch));
+            var response = await _repositoryApi.CreateBranchAsync(project.Git.Id, new GitProviderApiClient.Model.CreateBranchRequest(branchName, branch.GitBranch));
             branchName = response.Name;
 
 


### PR DESCRIPTION
This PR contains changes in:

**Balsam API**
- CreateBranch send the git branch name instead of the Balsam branch id