### PR TITLE
Fixed instructions and the helm chart

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -230,7 +230,7 @@ helm install rocketchat rocketchat/rocketchat -f RocketChat/values.yaml --namesp
 ## Install Balsam
 Use helm to install Balsam
 ```bash
-helm install balsam oci://registry-1.docker.io/statisticssweden/balsam-chart --version 0.1.1 -f YOUR-VALUES-FILE.yaml
+helm install balsam oci://registry-1.docker.io/statisticssweden/balsam-chart --version 0.1.2 -f YOUR-VALUES-FILE.yaml
 ```
 Use the following values template and replace the placeholder with your settings.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -196,6 +196,14 @@ helm install rocketchat rocketchat/rocketchat -f RocketChat/values.yaml --namesp
 
 
 ## Configure and install a Balsam hub
+### Configure GitLab
+1. Sign in with the KeyCloak user for GitLab and sign out (So that the user is created in GitLab).
+2. Sign in with the root account in GitLab. Password is in secret `gitlab-gitlab-initial-root-password`. 
+3. Make KeyCloak user an admin.
+4. Sign in with KeyCloak user and create a personal access token.
+5. Create a new Group.
+6. Remove the branch protection rules in the new group.
+
 ### Prepare hub repository
 1. Create a private Git repository (will conatin sensitive information so keep it private)
 2. Copy the files from `dependencies/HubRepoTemplates` and changes the placeholder in the templates in the format `<PLACEHOLDER>` and commit it to the repository
@@ -210,14 +218,6 @@ helm install rocketchat rocketchat/rocketchat -f RocketChat/values.yaml --namesp
 ### Configure MinIO
 1. Sign in with the userer from keycloak in MinIO console.
 2. Create a accesskey with full rights.
-
-### Configure GitLab
-1. Sign in with the KeyCloak user for GitLab and sign out (So that the user is created in GitLab).
-2. Sign in with the root account in GitLab. Password is in secret `gitlab-gitlab-initial-root-password`. 
-3. Make KeyCloak user an admin.
-4. Sign in with KeyCloak user and create a personal access token.
-5. Create a new Group.
-6. Remove the branch protection rules in the new group.
 
 ### Configure RocketChat
 1. Sign in as admin.
@@ -273,7 +273,7 @@ gitProvider:
   secret:
     name: gitlab-provider-secret
     data:
-      API__PAT: <GITLAB-PATH>
+      API__PAT: <GITLAB-PAT>
   configMap:
     name: gitlab-provider-config
     data:
@@ -298,11 +298,12 @@ oidcProvider:
 chatProvider: 
   secret:
     name: rocketchat-provider-secret
+    data:
+      API__Token: "<ROCKETCHAT-TOKEN>"
   configMap:
     name: rocketchat-provider-config
     data:
       API__BaseUrl: "<ROCKETCHAT-URL>"
-      API__Token: "<ROCKETCHAT-TOKEN>"
       API__UserId: "<ROCKETCHAT-USER>"
 
 roleBinding:

--- a/src/helm/balsam-chart/Chart.yaml
+++ b/src/helm/balsam-chart/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/helm/balsam-chart/Chart.yaml
+++ b/src/helm/balsam-chart/Chart.yaml
@@ -12,4 +12,4 @@ version: 0.1.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.1"
+appVersion: "0.1.2"

--- a/src/helm/balsam-chart/templates/balsam-api-deployment.yaml
+++ b/src/helm/balsam-chart/templates/balsam-api-deployment.yaml
@@ -32,10 +32,14 @@ spec:
           value: "http://git-provider.balsam-system.svc.cluster.local/api/v1"
         - name: Capabilities__S3__ServiceLocation
           value: "http://s3-provider.balsam-system.svc.cluster.local/api/v1"
+        - name: Capabilities__S3__Enabled
+          value: "{{ .Values.s3Provider.enabled }}"
         - name: Capabilities__AUTHENTICATION__ServiceLocation
           value: "http://oidc-provider.balsam-system.svc.cluster.local/api/v1"
         - name: Capabilities__CHAT__ServiceLocation
           value: "http://chat-provider.balsam-system.svc.cluster.local/api/v1"
+        - name: Capabilities__CHAT__Enabled
+          value: "{{ .Values.chatProvider.enabled }}"
         resources:
           requests:
             memory: "200Mi"

--- a/src/helm/balsam-chart/templates/balsam-ui-configmap.yaml
+++ b/src/helm/balsam-chart/templates/balsam-ui-configmap.yaml
@@ -6,7 +6,8 @@ metadata:
 data:
   config.json: |-
     {
-        "apiurl": "http://{{ .Values.balsamApi.ingress.hosts.host }}/api/v1"
+        "apiurl": "http://{{ .Values.balsamApi.ingress.hosts.host }}/api/v1",
+        "defaultGitBranchName": "{{ .Values.balsamUi.configMap.defaultBranchName }}"
     }
   keycloak.json: |-
     {

--- a/src/helm/balsam-chart/templates/chat-provider-configmap.yaml
+++ b/src/helm/balsam-chart/templates/chat-provider-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.chatProvider.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,5 +6,5 @@ metadata:
   namespace: balsam-system
 data: 
   API__BaseUrl: "{{ .Values.chatProvider.configMap.data.API__BaseUrl }}"
-  API__Token: {{ .Values.chatProvider.configMap.data.API__Token }}
   API__UserId: {{ .Values.chatProvider.configMap.data.API__UserId }}
+{{- end }}

--- a/src/helm/balsam-chart/templates/chat-provider-deployment.yaml
+++ b/src/helm/balsam-chart/templates/chat-provider-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.chatProvider.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,3 +37,4 @@ spec:
             cpu: "500m"
         ports:
         - containerPort: {{ .Values.chatProvider.containerPort }}
+{{- end }}

--- a/src/helm/balsam-chart/templates/chat-provider-secret.yaml
+++ b/src/helm/balsam-chart/templates/chat-provider-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.chatProvider.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,4 +6,5 @@ metadata:
   namespace: balsam-system
 type: Opaque
 data:
-  ROCKETCHAT__PAT: {{ .Values.chatProvider.secret.data.ROCKETCHAT__PAT | b64enc }}
+  API__Token: {{ .Values.chatProvider.secret.data.API__Token | b64enc }}
+{{- end }}

--- a/src/helm/balsam-chart/templates/chat-provider-service.yaml
+++ b/src/helm/balsam-chart/templates/chat-provider-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.chatProvider.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,3 +12,4 @@ spec:
     - protocol: TCP
       port: {{ .Values.chatProvider.service.port }}
       targetPort: {{ .Values.chatProvider.containerPort }}
+{{- end }}

--- a/src/helm/balsam-chart/templates/s3-provider-configmap.yaml
+++ b/src/helm/balsam-chart/templates/s3-provider-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.s3Provider.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
 data: 
   API__DOMAIN: {{ .Values.s3Provider.configMap.data.API__DOMAIN }} 
   API__PROTOCOL: {{ .Values.s3Provider.configMap.data.API__PROTOCOL }}
+{{- end }}

--- a/src/helm/balsam-chart/templates/s3-provider-deployment.yaml
+++ b/src/helm/balsam-chart/templates/s3-provider-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.s3Provider.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,3 +46,4 @@ spec:
         - name: s3-templates
           configMap:
             name: s3-templates
+{{- end }}

--- a/src/helm/balsam-chart/templates/s3-provider-secret.yaml
+++ b/src/helm/balsam-chart/templates/s3-provider-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.s3Provider.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ type: Opaque
 data:
   API__ACCESSKEY: {{ .Values.s3Provider.secret.data.API__ACCESSKEY | b64enc }}
   API__SECRETKEY: {{ .Values.s3Provider.secret.data.API__SECRETKEY | b64enc }}
+{{- end }}

--- a/src/helm/balsam-chart/templates/s3-provider-service.yaml
+++ b/src/helm/balsam-chart/templates/s3-provider-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.s3Provider.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,3 +12,4 @@ spec:
     - protocol: TCP
       port: {{ .Values.s3Provider.service.port }}
       targetPort: {{ .Values.s3Provider.containerPort }}
+{{- end }}

--- a/src/helm/balsam-chart/templates/s3-provider-templates.yaml
+++ b/src/helm/balsam-chart/templates/s3-provider-templates.yaml
@@ -1,6 +1,8 @@
+{{- if .Values.s3Provider.enabled -}}
 apiVersion: v1
 data:
   readme.txt: Empty
 kind: ConfigMap
 metadata:
   name: s3-templates
+{{- end }}

--- a/src/helm/balsam-chart/values.yaml
+++ b/src/helm/balsam-chart/values.yaml
@@ -46,6 +46,7 @@ balsamUi:
   containerPort: 8080 #8080?
   configMap:
     name: balsam-ui-config
+    defaultBranchName: main
   ingress:
     enabled: true
     annotations: {
@@ -57,6 +58,7 @@ balsamUi:
 
 
 s3Provider:
+  enabled: true
   image:
     repository: statisticssweden/balsam-minio-s3-provider # The repository for the s3Provider API
     pullPolicy: Always
@@ -121,6 +123,7 @@ gitProvider:
       API__TemplatePath: /app/templates
 
 chatProvider:
+  enabled: true
   image:
     repository: statisticssweden/balsam-rocketchat-chat-provider # The repository for the chatProvider API
     pullPolicy: Always
@@ -133,12 +136,11 @@ chatProvider:
   secret:
     name: rocketchat-provider-secret
     data:
-      ROCKETCHAT__PAT: # The PAT used by the chatprovider API
+      API__Token: ###
   configMap:
     name: rocketchat-provider-config
     data:
       API__BaseUrl: ###
-      API__Token: ###
       API__UserId: ###
 
 serviceAccount:

--- a/src/helm/balsam-chart/values.yaml
+++ b/src/helm/balsam-chart/values.yaml
@@ -37,7 +37,7 @@ balsamUi:
     repository: statisticssweden/balsam-ui # The repository for balsamUi
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.1.2 # The tag for balsamUi
+    tag: 0.1.3 # The tag for balsamUi
   service:
     type: ClusterIP
     port: 80

--- a/src/helm/balsam-chart/values.yaml
+++ b/src/helm/balsam-chart/values.yaml
@@ -9,7 +9,7 @@ balsamApi:
     repository: statisticssweden/balsam-api # The repository for balsamApi
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.1.1 # The tag for balsamApi
+    tag: 0.1.2 # The tag for balsamApi
   service:
     type: ClusterIP
     port: 80
@@ -37,7 +37,7 @@ balsamUi:
     repository: statisticssweden/balsam-ui # The repository for balsamUi
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.1.1 # The tag for balsamUi
+    tag: 0.1.2 # The tag for balsamUi
   service:
     type: ClusterIP
     port: 80

--- a/src/helm/balsam-chart/values.yaml
+++ b/src/helm/balsam-chart/values.yaml
@@ -27,8 +27,6 @@ balsamApi:
   ingress:
     enabled: true
     annotations: {
-      kubernetes.io/ingress.class: "contour",
-      cert-manager.io/cluster-issuer: ca-issuer,
       kubernetes.io/ingress.allow-http: "true"
     }
     hosts:
@@ -50,7 +48,6 @@ balsamUi:
   ingress:
     enabled: true
     annotations: {
-      kubernetes.io/ingress.class: "contour",
       kubernetes.io/ingress.allow-http: "true"
     }
     hosts:


### PR DESCRIPTION
This PR includes

- Changes in the installation instruction.
- Changes in the Helm chart
 - Made chatProvider an optional install
 - Made s3Provider an optional install (but should for now always be installed)
 - Added variable for defaultBranchName
 - Removed default annotations on the ingresses
 - updated image tags for Balsam API and Balsam UI