### PR TITLE
Fix hard coding of master

### DIFF
--- a/src/Balsam/src/Balsam.Api/HubRepositoryClient.cs
+++ b/src/Balsam/src/Balsam.Api/HubRepositoryClient.cs
@@ -62,8 +62,7 @@ namespace Balsam.Api
 
             var remote = _repository.Network.Remotes["origin"];
 
-            var pushRefSpec = @"refs/heads/master";
-            _repository.Network.Push(remote, pushRefSpec, pushOptions);
+            _repository.Network.Push(remote, _repository.Head.CanonicalName, pushOptions);
         }
 
         public void PullChanges()


### PR DESCRIPTION
This PR contains changes in:

** Balsam API **
- Removed hard coding of default git branch from master used HEAD instead for Hub repository.