### PR TITLE
Aded code for removing the git branch

### DIFF
--- a/src/Balsam/src/Balsam.Api/HubClient.cs
+++ b/src/Balsam/src/Balsam.Api/HubClient.cs
@@ -727,6 +727,19 @@ namespace Balsam.Api
                 }
             }
 
+            if (_git.Enabled)
+            {
+                try
+                {
+                    await _repositoryApi.DeleteRepositoryBranchAsync(project.Git?.Id ?? "", branch.GitBranch);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Could not delete git branch");
+                }
+            }
+
+
             _hubRepositoryClient.PullChanges();
 
             if (Directory.Exists(branchPath))


### PR DESCRIPTION
Updated Balsam API so that it also removes the git-branch when removing the Balsam branch